### PR TITLE
add link-image to math-comp book

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head>
-<!-- 2020-10-14 Wed 17:47 -->
+<!-- 2020-10-14 Wed 18:01 -->
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Mathematical Components</title>
@@ -242,9 +242,9 @@ for the JavaScript code in this tag.
  <img src="https://github.githubassets.com/images/modules/logos_page/Octocat.png" height="25" style="border:0px"></div>
 </p>
 
-<div id="outline-container-orgb143b0d" class="outline-2">
-<h2 id="orgb143b0d">About</h2>
-<div class="outline-text-2" id="text-orgb143b0d">
+<div id="outline-container-org1f8b72f" class="outline-2">
+<h2 id="org1f8b72f">About</h2>
+<div class="outline-text-2" id="text-org1f8b72f">
 <p>
 Welcome to Mathematical Components' web-page! 
 </p>
@@ -270,9 +270,9 @@ software license agreement.
 </div>
 </div>
 
-<div id="outline-container-orgc44401f" class="outline-2">
-<h2 id="orgc44401f">Get the library</h2>
-<div class="outline-text-2" id="text-orgc44401f">
+<div id="outline-container-orgb1873e4" class="outline-2">
+<h2 id="orgb1873e4">Get the library</h2>
+<div class="outline-text-2" id="text-orgb1873e4">
 <ul class="org-ul">
 <li><a href="installation.html">Here</a> are installation instructions.</li>
 <li>The current stable release of the Mathematical Components library
@@ -283,9 +283,14 @@ can be <a href="https://github.com/math-comp/math-comp/releases">downloaded from
 </div>
 
 
-<div id="outline-container-org59683a7" class="outline-2">
-<h2 id="org59683a7">Documentation</h2>
-<div class="outline-text-2" id="text-org59683a7">
+<div id="outline-container-org3341239" class="outline-2">
+<h2 id="org3341239">Documentation</h2>
+<div class="outline-text-2" id="text-org3341239">
+
+<div style="float: right; width: 240px; margin: 5px 10px">
+<a href="https://math-comp.github.io/mcb/"><img alt="Mathematical Components book" src="https://math-comp.github.io/mcb/cover-front-web.png" style="width: 240px" border="1px solid black"></a>
+</div>
+
 <ul class="org-ul">
 <li>The source file of each library features a documentation header
 which describes the concepts and notations introduced in that library.
@@ -302,9 +307,9 @@ library.</li>
 </ul>
 </div>
 
-<div id="outline-container-org14b29f5" class="outline-3">
-<h3 id="org14b29f5">More material</h3>
-<div class="outline-text-3" id="text-org14b29f5">
+<div id="outline-container-orgbb3f964" class="outline-3">
+<h3 id="orgbb3f964">More material</h3>
+<div class="outline-text-3" id="text-orgbb3f964">
 <ul class="org-ul">
 <li><a href="documentation.html">Books, lectures, videos, etc.</a></li>
 <li><a href="papers.html">Research papers</a> related to Mathematical Components. Your paper or
@@ -315,9 +320,9 @@ thesis is not in the list? Send <a href="mailto:mathcomp-dev@inria.fr?subject=Ma
 </div>
 
 
-<div id="outline-container-orgf389a06" class="outline-2">
-<h2 id="orgf389a06">Help and contact</h2>
-<div class="outline-text-2" id="text-orgf389a06">
+<div id="outline-container-org94f864d" class="outline-2">
+<h2 id="org94f864d">Help and contact</h2>
+<div class="outline-text-2" id="text-org94f864d">
 <ul class="org-ul">
 <li>Chat with us on <a href="https://coq.zulipchat.com/">Coq's Zulip</a>!</li>
 <li>Discuss with us on Coq's <a href="https://coq.discourse.group/">Discourse</a> forum!</li>
@@ -327,9 +332,9 @@ thesis is not in the list? Send <a href="mailto:mathcomp-dev@inria.fr?subject=Ma
 </div>
 </div>
 
-<div id="outline-container-org60715dd" class="outline-2">
-<h2 id="org60715dd">Authors and contributors</h2>
-<div class="outline-text-2" id="text-org60715dd">
+<div id="outline-container-org016b4d9" class="outline-2">
+<h2 id="org016b4d9">Authors and contributors</h2>
+<div class="outline-text-2" id="text-org016b4d9">
 <p>
 The Mathematical Components library and the Ssreflect proof language
 were initially developed by the <a href="http://www.msr-inria.fr/projects/mathematical-components-2/">Mathematical Components team</a> at the

--- a/index.org
+++ b/index.org
@@ -41,6 +41,14 @@ software license agreement.
 
 * Documentation
 
+#+BEGIN_EXPORT html
+
+<div style="float: right; width: 240px; margin: 5px 10px">
+<a href="https://math-comp.github.io/mcb/"><img alt="Mathematical Components book" src="https://math-comp.github.io/mcb/cover-front-web.png" style="width: 240px" border="1px solid black"></a>
+</div>
+
+#+END_EXPORT
+
 - The source file of each library features a documentation header
   which describes the concepts and notations introduced in that library.
   + The [[file:htmldoc/index.html][coqdoc presentation]] of the source files can be browsed online.


### PR DESCRIPTION
I propose to add an image and a link to the MathComp book to the entry page.