### PR TITLE
update installation instruction about analysis

### DIFF
--- a/installation.html
+++ b/installation.html
@@ -3,7 +3,7 @@
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head>
-<!-- 2020-04-18 Sat 02:20 -->
+<!-- 2021-12-16 Thu 12:23 -->
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Mathematical Components: Installation</title>
@@ -161,6 +161,19 @@
   .footdef  { margin-bottom: 1em; }
   .figure { padding: 1em; }
   .figure p { text-align: center; }
+  .equation-container {
+    display: table;
+    text-align: center;
+    width: 100%;
+  }
+  .equation {
+    vertical-align: middle;
+  }
+  .equation-label {
+    display: table-cell;
+    text-align: right;
+    vertical-align: middle;
+  }
   .inlinetask {
     padding: 10px;
     border: 2px solid gray;
@@ -191,7 +204,7 @@
 @licstart  The following is the entire license notice for the
 JavaScript code in this tag.
 
-Copyright (C) 2012-2018 Free Software Foundation, Inc.
+Copyright (C) 2012-2020 Free Software Foundation, Inc.
 
 The JavaScript code in this tag is free software: you can
 redistribute it and/or modify it under the terms of the GNU
@@ -237,9 +250,9 @@ for the JavaScript code in this tag.
 <div id="content">
 <h1 class="title">Mathematical Components: Installation</h1>
 
-<div id="outline-container-org9c2efce" class="outline-2">
-<h2 id="org9c2efce">Install the Base Mathematical Components Libraries</h2>
-<div class="outline-text-2" id="text-org9c2efce">
+<div id="outline-container-org6a80149" class="outline-2">
+<h2 id="org6a80149">Install the Base Mathematical Components Libraries</h2>
+<div class="outline-text-2" id="text-org6a80149">
 <ul class="org-ul">
 <li>The installation of Mathematical Components is best done using <a href="https://opam.ocaml.org/">opam</a>,
 a package manager for <a href="https://ocaml.org/">OCaml</a>, the programming language with which <a href="https://coq.inria.fr/">Coq</a>
@@ -273,9 +286,9 @@ in the <a href="https://coq.inria.fr/opam/www/">Coq package index</a>, e.g.:
 </ul>
 </div>
 
-<div id="outline-container-org42c0690" class="outline-3">
-<h3 id="org42c0690">Installation Instructions in Other Languages</h3>
-<div class="outline-text-3" id="text-org42c0690">
+<div id="outline-container-org2039808" class="outline-3">
+<h3 id="org2039808">Installation Instructions in Other Languages</h3>
+<div class="outline-text-3" id="text-org2039808">
 <ul class="org-ul">
 <li>Installation instructions in <a href="https://staff.aist.go.jp/reynald.affeldt/ssrcoq/install.html">Japanese, 日本語</a>
 <ul class="org-ul">
@@ -285,9 +298,9 @@ in the <a href="https://coq.inria.fr/opam/www/">Coq package index</a>, e.g.:
 </div>
 </div>
 
-<div id="outline-container-org27f9ccf" class="outline-3">
-<h3 id="org27f9ccf">Installation Instructions for Windows 10</h3>
-<div class="outline-text-3" id="text-org27f9ccf">
+<div id="outline-container-org0b00a81" class="outline-3">
+<h3 id="org0b00a81">Installation Instructions for Windows 10</h3>
+<div class="outline-text-3" id="text-org0b00a81">
 <ul class="org-ul">
 <li>It is possible to install the Mathematical Components libraries on
 Windows 10 using <a href="https://www.cygwin.com/">cygwin</a> together with the binary distribution of Coq
@@ -298,26 +311,26 @@ Linux, as explained for example <a href="https://github.com/affeldt-aist/mathcom
 </div>
 </div>
 
-<div id="outline-container-org91d479e" class="outline-2">
-<h2 id="org91d479e">Other Mathematical Components Libraries</h2>
-<div class="outline-text-2" id="text-org91d479e">
+<div id="outline-container-org17b8cec" class="outline-2">
+<h2 id="org17b8cec">Other Mathematical Components Libraries</h2>
+<div class="outline-text-2" id="text-org17b8cec">
 <p>
 There are already several libraries that build on top of the base
 Mathematical Components libraries:
 </p>
 
 <ol class="org-ol">
-<li>The Four Color theorem
+<li><a href="https://github.com/math-comp/fourcolor">The Four Color theorem</a>
 <ul class="org-ul">
 <li>Available as the opam package <code>coq-fourcolor</code></li>
 </ul></li>
-<li>The Odd Order theorem
+<li><a href="https://github.com/math-comp/odd-order">The Odd Order theorem</a>
 <ul class="org-ul">
 <li>Available as the opam package <code>coq-mathcomp-odd-order</code></li>
 </ul></li>
-<li>MathComp Analysis
+<li><a href="https://github.com/math-comp/analysis">MathComp Analysis</a> (WIP)
 <ul class="org-ul">
-<li>WIP, see <a href="https://github.com/math-comp/analysis/blob/master/INSTALL.md">INSTALL.md</a></li>
+<li>Available as the opam package <code>coq-mathcomp-analysis</code></li>
 </ul></li>
 <li>See the Mathematical Components' <a href="https://github.com/math-comp">github</a> for more libraries</li>
 </ol>

--- a/installation.org
+++ b/installation.org
@@ -53,11 +53,11 @@ opam install coq-mathcomp-ssreflect
 There are already several libraries that build on top of the base
 Mathematical Components libraries:
 
-1. The Four Color theorem
+1. [[https://github.com/math-comp/fourcolor][The Four Color theorem]]
    - Available as the opam package ~coq-fourcolor~
-2. The Odd Order theorem
+2. [[https://github.com/math-comp/odd-order][The Odd Order theorem]]
    - Available as the opam package ~coq-mathcomp-odd-order~
-3. MathComp Analysis
-  - WIP, see [[https://github.com/math-comp/analysis/blob/master/INSTALL.md][INSTALL.md]]
+3. [[https://github.com/math-comp/analysis][MathComp Analysis]] (WIP)
+   - Available as the opam package ~coq-mathcomp-analysis~
 4. See the Mathematical Components' [[https://github.com/math-comp][github]] for more libraries
 


### PR DESCRIPTION
The installation instructions for mathcomp-analysis were marked as WIP with a link to an INSTALL.md.
This PR updates the link to the github repo and now mentions the availability of an opam package.