### PR TITLE
add CPP 2011 paper by Coquand and Siles on regexps

### DIFF
--- a/papers.html
+++ b/papers.html
@@ -551,6 +551,8 @@ JAR 56, 2016. <a href="https://doi.org/10.1007/s10817-016-9361-9">doi</a></li>
 <span class="underline">Constructive Completeness for Modal Logic with Transitive Closure</span>. CPP 2012. <a href="https://doi.org/10.1007/978-3-642-35308-6_18">doi</a></li>
 <li>Christian Doczkal, Gert Smolka.
 <span class="underline">Constructive Formalization of Hybrid Logic with Eventualities</span>. CPP 2011. <a href="https://www.ps.uni-saarland.de/Publications/documents/DoczkalSmolka_2011_Constructive_0.pdf">pdf</a></li>
+<li>Thierry Coquand, Vincent Siles.
+<span class="underline">A Decision Procedure for Regular Expression Equivalence in Type Theory</span>. CPP 2011. <a href="https://doi.org/10.1007/978-3-642-25379-9_11">doi</a></li>
 <li>Kasper Svendsen, Lars Birkedal, Aleksandar Nanevski.
  <span class="underline">Partiality, State and Dependent Types</span>.
 International Conference on Typed Lambda Calculi and Applications (TLCA 2011). <a href="https://doi.org/10.1007/978-3-642-21691-6_17">doi</a></li>

--- a/papers.html
+++ b/papers.html
@@ -537,6 +537,8 @@ JAR 61, 2018. <a href="https://hal.archives-ouvertes.fr/hal-01832031/document">p
 <li>Christian Doczkal, Joachim Bard.
 <span class="underline">Completeness and Decidability of Converse PDL in the Constructive Type Theory of Coq</span>.
 CPP 2018. <a href="https://hal.archives-ouvertes.fr/hal-01646782/document">pdf</a></li>
+<li>Angela Bonifati, Stefania Dumbrava, Emilio Jesús Gallego Arias.
+<span class="underline">Certified Graph View Maintenance with Regular Datalog</span>. ICLP 2018. <a href="https://hal.archives-ouvertes.fr/hal-01932818/document">pdf</a></li>
 <li>Véronique Benzaken, Evelyne Contejean, Stefania Dumbrava.
 <span class="underline">Certifying Standard and Stratified Datalog Inference Engines in SSReflect</span>. ITP 2017. <a href="https://hal.archives-ouvertes.fr/hal-01745566/file/ITP2017.pdf">pdf</a></li>
 <li>Felipe Cerqueira, Felix Stutz, Björn Brandenburg.

--- a/papers.org
+++ b/papers.org
@@ -245,6 +245,8 @@ This is a memo to serve in the event we change the sectioning
 - Christian Doczkal, Joachim Bard.
   _Completeness and Decidability of Converse PDL in the Constructive Type Theory of Coq_.
   CPP 2018. [[https://hal.archives-ouvertes.fr/hal-01646782/document][pdf]]
+- Angela Bonifati, Stefania Dumbrava, Emilio Jesús Gallego Arias.
+  _Certified Graph View Maintenance with Regular Datalog_. ICLP 2018. [[https://hal.archives-ouvertes.fr/hal-01932818/document][pdf]]
 - Véronique Benzaken, Evelyne Contejean, Stefania Dumbrava.
   _Certifying Standard and Stratified Datalog Inference Engines in SSReflect_. ITP 2017. [[https://hal.archives-ouvertes.fr/hal-01745566/file/ITP2017.pdf][pdf]]
 - Felipe Cerqueira, Felix Stutz, Björn Brandenburg.

--- a/papers.org
+++ b/papers.org
@@ -259,6 +259,8 @@ This is a memo to serve in the event we change the sectioning
   _Constructive Completeness for Modal Logic with Transitive Closure_. CPP 2012. [[https://doi.org/10.1007/978-3-642-35308-6_18][doi]]
 - Christian Doczkal, Gert Smolka.
   _Constructive Formalization of Hybrid Logic with Eventualities_. CPP 2011. [[https://www.ps.uni-saarland.de/Publications/documents/DoczkalSmolka_2011_Constructive_0.pdf][pdf]]
+- Thierry Coquand, Vincent Siles.
+  _A Decision Procedure for Regular Expression Equivalence in Type Theory_. CPP 2011. [[https://doi.org/10.1007/978-3-642-25379-9_11][doi]]
 - Kasper Svendsen, Lars Birkedal, Aleksandar Nanevski.
    _Partiality, State and Dependent Types_.
   International Conference on Typed Lambda Calculi and Applications (TLCA 2011). [[https://doi.org/10.1007/978-3-642-21691-6_17][doi]]


### PR DESCRIPTION
In Coq-community, we have recently revived a Coq project from 2011 by Coquand and Siles that formalizes decision procedures on regular expression equivalence using MathComp and SSReflect: https://github.com/coq-community/regexp-Brzozowski

In this PR, I add the corresponding paper to the list of papers.