### PR TITLE
consolidate distributed systems papers under concurrency header

### DIFF
--- a/papers.html
+++ b/papers.html
@@ -457,11 +457,16 @@ Master’s thesis, Mathematics, Radboud University, 2016. <a href="https://www.r
 <h3 id="orgb50a12a">Concurrency</h3>
 <div class="outline-text-3" id="text-orgb50a12a">
 <ul class="org-ul">
+<li>Søren Eller Thomsen, Bas Spitters.
+<span class="underline">Formalizing Nakamoto-Style Proof of Stake</span>. CSF 2021. <a href="https://arxiv.org/pdf/2007.12105">pdf</a></li>
+<li>Musab A. Alturki, Jing Chen, Victor Luchangco, Brandon Moore, Karl Palmskog, Lucas Peña, Grigore Roşu.
+<span class="underline">Towards a Verified Model of the Algorand Consensus Protocol in Coq</span>. FMBC 2019. <a href="https://arxiv.org/pdf/1907.05523">pdf</a></li>
 <li>Joseph Tassarotti, Robert Harper.
 <span class="underline">A Separation Logic for Concurrent Randomized Programs</span>.
 POPL 2019. <a href="http://www.cs.bc.edu/~tassarot/papers/iris-prob-paper/paper.pdf">pdf</a></li>
 <li>Ilya Sergey, James R. Wilcox, Zachary Tatlock.
 <span class="underline">Programming and Proving with Distributed Protocols</span>. POPL 2018. <a href="https://dl.acm.org/citation.cfm?doid=3177123.3158116">pdf</a></li>
+<li>George Pîrlea, Ilya Sergey. <span class="underline">Mechanising Blockchain Consensus</span>. CPP 2018. <a href="https://dl.acm.org/citation.cfm?id=3167086">pdf</a></li>
 <li>Germán Andrés Delbianco, Ilya Sergey, Aleksandar Nanevski, Anindya Banerjee.
 <span class="underline">Concurrent Data Structures Linked in Time</span>. ECOOP 2017. <a href="https://drops.dagstuhl.de/opus/volltexte/2017/7255/pdf/LIPIcs-ECOOP-2017-8.pdf">pdf</a></li>
 <li>Mitsuharu Yamamoto, Shogo Sekine, Saki Matsumoto.
@@ -526,7 +531,6 @@ Computer Software 37(3):79-95, 2020. <a href="https://staff.aist.go.jp/reynald.a
 <ul class="org-ul">
 <li>Pierre-Léo Bégay, Pierre Crégut, Jean-François Monin.
 <span class="underline">Developing and certifying Datalog optimizations in Coq/MathComp</span>. CPP 2021. <a href="https://hal.archives-ouvertes.fr/hal-03065304v1/document">pdf</a></li>
-<li>George Pîrlea, Ilya Sergey. <span class="underline">Mechanising Blockchain Consensus</span>. CPP 2018. <a href="https://dl.acm.org/citation.cfm?id=3167086">pdf</a></li>
 <li>Gallego Arias, Emilio Jesús, Olivier Hermant, Pierre Jouvelot.
 <span class="underline">A Taste of Sound Reasoning in Faust</span>.
 Linux Audio Conference 2015. <a href="https://github.com/ejgallego/mini-faust-coq">paper, code, slides</a></li>

--- a/papers.org
+++ b/papers.org
@@ -185,11 +185,16 @@ This is a memo to serve in the event we change the sectioning
 
 ** Concurrency
 
+- Søren Eller Thomsen, Bas Spitters.
+  _Formalizing Nakamoto-Style Proof of Stake_. CSF 2021. [[https://arxiv.org/pdf/2007.12105][pdf]]
+- Musab A. Alturki, Jing Chen, Victor Luchangco, Brandon Moore, Karl Palmskog, Lucas Peña, Grigore Roşu.
+  _Towards a Verified Model of the Algorand Consensus Protocol in Coq_. FMBC 2019. [[https://arxiv.org/pdf/1907.05523][pdf]]
 - Joseph Tassarotti, Robert Harper.
   _A Separation Logic for Concurrent Randomized Programs_.
   POPL 2019. [[http://www.cs.bc.edu/~tassarot/papers/iris-prob-paper/paper.pdf][pdf]]
 - Ilya Sergey, James R. Wilcox, Zachary Tatlock.
    _Programming and Proving with Distributed Protocols_. POPL 2018. [[https://dl.acm.org/citation.cfm?doid=3177123.3158116][pdf]]
+- George Pîrlea, Ilya Sergey. _Mechanising Blockchain Consensus_. CPP 2018. [[https://dl.acm.org/citation.cfm?id=3167086][pdf]]
 - Germán Andrés Delbianco, Ilya Sergey, Aleksandar Nanevski, Anindya Banerjee.
   _Concurrent Data Structures Linked in Time_. ECOOP 2017. [[https://drops.dagstuhl.de/opus/volltexte/2017/7255/pdf/LIPIcs-ECOOP-2017-8.pdf][pdf]]
 - Mitsuharu Yamamoto, Shogo Sekine, Saki Matsumoto.
@@ -238,7 +243,6 @@ This is a memo to serve in the event we change the sectioning
 
 - Pierre-Léo Bégay, Pierre Crégut, Jean-François Monin.
   _Developing and certifying Datalog optimizations in Coq/MathComp_. CPP 2021. [[https://hal.archives-ouvertes.fr/hal-03065304v1/document][pdf]]
-- George Pîrlea, Ilya Sergey. _Mechanising Blockchain Consensus_. CPP 2018. [[https://dl.acm.org/citation.cfm?id=3167086][pdf]]
 - Gallego Arias, Emilio Jesús, Olivier Hermant, Pierre Jouvelot.
   _A Taste of Sound Reasoning in Faust_.
   Linux Audio Conference 2015. [[https://github.com/ejgallego/mini-faust-coq][paper, code, slides]]


### PR DESCRIPTION
To keep the number of categories down, it probably makes sense to have all distributed systems (blockchain) papers under "Concurrency" (which is technically true). Here I move one blockchain paper from elsewhere to concurrency and add two new blockchain papers.