### PR TITLE
a few papers from CPP 2023 and other conferences

### DIFF
--- a/papers.html
+++ b/papers.html
@@ -3,7 +3,7 @@
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head>
-<!-- 2023-01-31 Tue 17:37 -->
+<!-- 2023-01-31 Tue 21:02 -->
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Mathematical Components: Research Papers</title>
@@ -253,10 +253,10 @@ for the JavaScript code in this tag.
 <h2>Table of Contents</h2>
 <div id="text-table-of-contents">
 <ul>
-<li><a href="#org8f5e9f7">Mathematics</a></li>
-<li><a href="#org8fed763">Programming and Algorithms</a></li>
-<li><a href="#orgbbd09cb">Other Applications</a></li>
-<li><a href="#orgda370c1">Tooling about SSReflect and Mathematical Components</a></li>
+<li><a href="#org655f51d">Mathematics</a></li>
+<li><a href="#orgf54656d">Programming and Algorithms</a></li>
+<li><a href="#org3b0a667">Other Applications</a></li>
+<li><a href="#org6d12ca7">Tooling about SSReflect and Mathematical Components</a></li>
 </ul>
 </div>
 </div>
@@ -283,9 +283,9 @@ Your paper/thesis is not in the list? You have a suggestion about the organizati
 Please, send <a href="mailto:mathcomp-dev@inria.fr?subject=MathComp%20related%20paper">us</a> a message or <a href="https://github.com/math-comp/math-comp.github.io">issue/PR on github</a>.
 </p>
 
-<div id="outline-container-org8f5e9f7" class="outline-2">
-<h2 id="org8f5e9f7">Mathematics</h2>
-<div class="outline-text-2" id="text-org8f5e9f7">
+<div id="outline-container-org655f51d" class="outline-2">
+<h2 id="org655f51d">Mathematics</h2>
+<div class="outline-text-2" id="text-org655f51d">
 <ul class="org-ul">
 <li>Xavier Allamigeon, Quentin Canu, Pierre-Yves Strub.
 <span class="underline">A Formal Disproof of Hirsch Conjecture</span>.
@@ -375,9 +375,9 @@ ITP 2008. <a href="https://hal.inria.fr/inria-00331193/document">pdf</a></li>
 </ul>
 </div>
 
-<div id="outline-container-orge763462" class="outline-3">
-<h3 id="orge763462">Graph Theory</h3>
-<div class="outline-text-3" id="text-orge763462">
+<div id="outline-container-org9592abd" class="outline-3">
+<h3 id="org9592abd">Graph Theory</h3>
+<div class="outline-text-3" id="text-org9592abd">
 <ul class="org-ul">
 <li>Christian Doczkal.
 <span class="underline">A Variant of Wagner’s Theorem Based on Combinatorial Hypermaps</span>.
@@ -399,9 +399,9 @@ CPP 2020. <a href="https://hal.archives-ouvertes.fr/hal-02333553/document">pdf</
 </div>
 </div>
 
-<div id="outline-container-orgfa350a8" class="outline-3">
-<h3 id="orgfa350a8">Robotics</h3>
-<div class="outline-text-3" id="text-orgfa350a8">
+<div id="outline-container-orgf147618" class="outline-3">
+<h3 id="orgf147618">Robotics</h3>
+<div class="outline-text-3" id="text-orgf147618">
 <ul class="org-ul">
 <li>Cyril Cohen, Damien Rouhling.
 <span class="underline">A Formal Proof in Coq of LaSalle's Invariance Principle</span>. ITP 2017. <a href="https://hal.inria.fr/hal-01612293/document">pdf</a></li>
@@ -412,9 +412,9 @@ CPP 2020. <a href="https://hal.archives-ouvertes.fr/hal-02333553/document">pdf</
 </div>
 </div>
 
-<div id="outline-container-org8fed763" class="outline-2">
-<h2 id="org8fed763">Programming and Algorithms</h2>
-<div class="outline-text-2" id="text-org8fed763">
+<div id="outline-container-orgf54656d" class="outline-2">
+<h2 id="orgf54656d">Programming and Algorithms</h2>
+<div class="outline-text-2" id="text-orgf54656d">
 <ul class="org-ul">
 <li>Li Zhou, Gilles Barthe, Pierre-Yves Strub, Junyi Liu, Mingsheng Ying.
 <span class="underline">CoqQ: Foundational Verification of Quantum Programs</span>.
@@ -465,9 +465,9 @@ Master’s thesis, Mathematics, Radboud University, 2016. <a href="https://www.r
 </ul>
 </div>
 
-<div id="outline-container-org3e8b7ee" class="outline-3">
-<h3 id="org3e8b7ee">Concurrency</h3>
-<div class="outline-text-3" id="text-org3e8b7ee">
+<div id="outline-container-org3cbfd65" class="outline-3">
+<h3 id="org3cbfd65">Concurrency</h3>
+<div class="outline-text-3" id="text-org3cbfd65">
 <ul class="org-ul">
 <li>Joseph Tassarotti, Robert Harper.
 <span class="underline">A Separation Logic for Concurrent Randomized Programs</span>.
@@ -497,9 +497,9 @@ ESOP 2014. <a href="https://doi.org/10.1007/978-3-642-54833-8_16">doi</a></li>
 </div>
 </div>
 
-<div id="outline-container-orge5d4d01" class="outline-3">
-<h3 id="orge5d4d01">Information Flow</h3>
-<div class="outline-text-3" id="text-orge5d4d01">
+<div id="outline-container-org85f34c3" class="outline-3">
+<h3 id="org85f34c3">Information Flow</h3>
+<div class="outline-text-3" id="text-org85f34c3">
 <ul class="org-ul">
 <li>Aleksandar Nanevski, Anindya Banerjee, Deepak Garg.
 <span class="underline">Dependent Type Theory for Verification of Information Flow and Access Control Policies</span>.
@@ -514,9 +514,9 @@ PPDP 2013. <a href="https://doi.org/10.1145/2505879.2505895">doi</a></li>
 </div>
 </div>
 
-<div id="outline-container-orgb58b163" class="outline-3">
-<h3 id="orgb58b163">Probabilistic Reasoning</h3>
-<div class="outline-text-3" id="text-orgb58b163">
+<div id="outline-container-org911e776" class="outline-3">
+<h3 id="org911e776">Probabilistic Reasoning</h3>
+<div class="outline-text-3" id="text-org911e776">
 <ul class="org-ul">
 <li>Kiran Gopinathan, Ilya Sergey.
 <span class="underline">Certifying Certainty and Uncertainty in Approximate Membership Query Structures</span>.
@@ -532,9 +532,9 @@ Computer Software 37(3):79-95, 2020. <a href="https://staff.aist.go.jp/reynald.a
 </div>
 </div>
 
-<div id="outline-container-orgbbd09cb" class="outline-2">
-<h2 id="orgbbd09cb">Other Applications</h2>
-<div class="outline-text-2" id="text-orgbbd09cb">
+<div id="outline-container-org3b0a667" class="outline-2">
+<h2 id="org3b0a667">Other Applications</h2>
+<div class="outline-text-2" id="text-org3b0a667">
 <ul class="org-ul">
 <li>Pierre-Léo Bégay, Pierre Crégut, Jean-François Monin.
 <span class="underline">Developing and certifying Datalog optimizations in Coq/MathComp</span>. CPP 2021. <a href="https://hal.archives-ouvertes.fr/hal-03065304v1/document">pdf</a></li>
@@ -549,9 +549,9 @@ Linux Audio Conference 2015. <a href="https://github.com/ejgallego/mini-faust-co
 </ul>
 </div>
 
-<div id="outline-container-org1de5e27" class="outline-3">
-<h3 id="org1de5e27">Logic, Types, and Verification</h3>
-<div class="outline-text-3" id="text-org1de5e27">
+<div id="outline-container-org0745872" class="outline-3">
+<h3 id="org0745872">Logic, Types, and Verification</h3>
+<div class="outline-text-3" id="text-org0745872">
 <ul class="org-ul">
 <li>Christian Doczkal, Gert Smolka.
 <span class="underline">Regular Language Representations in the Constructive Type Theory of Coq</span>.
@@ -584,9 +584,9 @@ International Conference on Typed Lambda Calculi and Applications (TLCA 2011). <
 </div>
 </div>
 
-<div id="outline-container-orgb7d806a" class="outline-3">
-<h3 id="orgb7d806a">Information Theory</h3>
-<div class="outline-text-3" id="text-orgb7d806a">
+<div id="outline-container-org09e0b8a" class="outline-3">
+<h3 id="org09e0b8a">Information Theory</h3>
+<div class="outline-text-3" id="text-org09e0b8a">
 <ul class="org-ul">
 <li>Joshua M. Cohen, Qinshi Wang, Andrew W. Appel.
 <span class="underline">Verified Erasure Correction in Coq with MathComp and VST</span>.
@@ -615,10 +615,13 @@ International Symposium on Information Theory and its Application 2014 (ISITA 20
 </div>
 </div>
 
-<div id="outline-container-orgda370c1" class="outline-2">
-<h2 id="orgda370c1">Tooling about SSReflect and Mathematical Components</h2>
-<div class="outline-text-2" id="text-orgda370c1">
+<div id="outline-container-org6d12ca7" class="outline-2">
+<h2 id="org6d12ca7">Tooling about SSReflect and Mathematical Components</h2>
+<div class="outline-text-2" id="text-org6d12ca7">
 <ul class="org-ul">
+<li>Valentin Blot, Denis Cousineau, Enzo Crance, Louise Dubois de Prisque, Chantal Keller, Assia Mahboubi, Pierre Vial.
+<span class="underline">Compositional Pre-processing for Automated Reasoning in Dependent Type Theory</span>.
+CPP 2023. <a href="https://arxiv.org/pdf/2204.02643.pdf">pdf</a></li>
 <li>Benjamin Grégoire, Jean-Christophe Léchenet, Enrico Tassi.
 _ Practical and sound equality tests, automatically_.
 CPP 2023. <a href="https://hal.inria.fr/hal-03800154/document">pdf</a></li>
@@ -655,9 +658,9 @@ IPSJ Transactions on Programming 10(1), 2017. <a href="http://logic.cs.tsukuba.a
 </ul>
 </div>
 
-<div id="outline-container-orgda7279c" class="outline-3">
-<h3 id="orgda7279c">Machine Learning</h3>
-<div class="outline-text-3" id="text-orgda7279c">
+<div id="outline-container-org44953dd" class="outline-3">
+<h3 id="org44953dd">Machine Learning</h3>
+<div class="outline-text-3" id="text-org44953dd">
 <ul class="org-ul">
 <li>Pengyu Nie, Karl Palmskog, Junyi Jessy Li, Milos Gligoric.
 <span class="underline">Deep Generation of Coq Lemma Names Using Elaborated Terms</span>. IJCAR 2020. <a href="https://arxiv.org/pdf/2004.07761.pdf">pdf</a></li>

--- a/papers.html
+++ b/papers.html
@@ -3,7 +3,7 @@
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head>
-<!-- 2022-07-12 Tue 20:25 -->
+<!-- 2023-01-31 Tue 17:37 -->
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Mathematical Components: Research Papers</title>
@@ -253,10 +253,10 @@ for the JavaScript code in this tag.
 <h2>Table of Contents</h2>
 <div id="text-table-of-contents">
 <ul>
-<li><a href="#org1bc4299">Mathematics</a></li>
-<li><a href="#orgb24784d">Programming and Algorithms</a></li>
-<li><a href="#orge13ccce">Other Applications</a></li>
-<li><a href="#org03a559d">Tooling about SSReflect and Mathematical Components</a></li>
+<li><a href="#org8f5e9f7">Mathematics</a></li>
+<li><a href="#org8fed763">Programming and Algorithms</a></li>
+<li><a href="#orgbbd09cb">Other Applications</a></li>
+<li><a href="#orgda370c1">Tooling about SSReflect and Mathematical Components</a></li>
 </ul>
 </div>
 </div>
@@ -283,10 +283,13 @@ Your paper/thesis is not in the list? You have a suggestion about the organizati
 Please, send <a href="mailto:mathcomp-dev@inria.fr?subject=MathComp%20related%20paper">us</a> a message or <a href="https://github.com/math-comp/math-comp.github.io">issue/PR on github</a>.
 </p>
 
-<div id="outline-container-org1bc4299" class="outline-2">
-<h2 id="org1bc4299">Mathematics</h2>
-<div class="outline-text-2" id="text-org1bc4299">
+<div id="outline-container-org8f5e9f7" class="outline-2">
+<h2 id="org8f5e9f7">Mathematics</h2>
+<div class="outline-text-2" id="text-org8f5e9f7">
 <ul class="org-ul">
+<li>Xavier Allamigeon, Quentin Canu, Pierre-Yves Strub.
+<span class="underline">A Formal Disproof of Hirsch Conjecture</span>.
+CPP 2023. <a href="https://arxiv.org/pdf/2301.04060.pdf">pdf</a></li>
 <li>Xavier Allamigeon, Ricardo D. Katz, Pierre-Yves Strub.
 <span class="underline">Formalizing the Face Lattice of Polyhedra</span>.
 LMCS 18(2), 2022. <a href="https://lmcs.episciences.org/9570/pdf">pdf</a></li>
@@ -372,9 +375,9 @@ ITP 2008. <a href="https://hal.inria.fr/inria-00331193/document">pdf</a></li>
 </ul>
 </div>
 
-<div id="outline-container-org9bcadd7" class="outline-3">
-<h3 id="org9bcadd7">Graph Theory</h3>
-<div class="outline-text-3" id="text-org9bcadd7">
+<div id="outline-container-orge763462" class="outline-3">
+<h3 id="orge763462">Graph Theory</h3>
+<div class="outline-text-3" id="text-orge763462">
 <ul class="org-ul">
 <li>Christian Doczkal.
 <span class="underline">A Variant of Wagner’s Theorem Based on Combinatorial Hypermaps</span>.
@@ -396,9 +399,9 @@ CPP 2020. <a href="https://hal.archives-ouvertes.fr/hal-02333553/document">pdf</
 </div>
 </div>
 
-<div id="outline-container-org593c0a8" class="outline-3">
-<h3 id="org593c0a8">Robotics</h3>
-<div class="outline-text-3" id="text-org593c0a8">
+<div id="outline-container-orgfa350a8" class="outline-3">
+<h3 id="orgfa350a8">Robotics</h3>
+<div class="outline-text-3" id="text-orgfa350a8">
 <ul class="org-ul">
 <li>Cyril Cohen, Damien Rouhling.
 <span class="underline">A Formal Proof in Coq of LaSalle's Invariance Principle</span>. ITP 2017. <a href="https://hal.inria.fr/hal-01612293/document">pdf</a></li>
@@ -409,10 +412,19 @@ CPP 2020. <a href="https://hal.archives-ouvertes.fr/hal-02333553/document">pdf</
 </div>
 </div>
 
-<div id="outline-container-orgb24784d" class="outline-2">
-<h2 id="orgb24784d">Programming and Algorithms</h2>
-<div class="outline-text-2" id="text-orgb24784d">
+<div id="outline-container-org8fed763" class="outline-2">
+<h2 id="org8fed763">Programming and Algorithms</h2>
+<div class="outline-text-2" id="text-org8fed763">
 <ul class="org-ul">
+<li>Li Zhou, Gilles Barthe, Pierre-Yves Strub, Junyi Liu, Mingsheng Ying.
+<span class="underline">CoqQ: Foundational Verification of Quantum Programs</span>.
+POPL 2023. <a href="https://arxiv.org/pdf/2207.11350.pdf">pdf</a></li>
+<li>Reynald Affeldt, Cyril Cohen, Ayumu Saito.
+<span class="underline">Semantics of Probabilistic Programs using s-Finite Kernels in Coq</span>.
+CPP 2023. <a href="https://hal.inria.fr/hal-03917948/document">pdf</a></li>
+<li>Ayumu Saito, Reynald Affeldt.
+<span class="underline">Towards a Practical Library for Monadic Equational Reasoning in Coq</span>.
+Mathematics of Program Construction (MPC 2022). <a href="https://staff.aist.go.jp/reynald.affeldt/documents/monae-mpc2022.pdf">pdf</a></li>
 <li>Reynald Affeldt, Jacques Garrigue, David Nowak, Takafumi Saikawa.
 <span class="underline">A trustful monad for axiomatic reasoning with probability and nondeterminism</span>.
 JFP 31(E17), 2021. <a href="https://arxiv.org/pdf/2003.09993.pdf">pdf</a></li>
@@ -453,9 +465,9 @@ Master’s thesis, Mathematics, Radboud University, 2016. <a href="https://www.r
 </ul>
 </div>
 
-<div id="outline-container-orgb50a12a" class="outline-3">
-<h3 id="orgb50a12a">Concurrency</h3>
-<div class="outline-text-3" id="text-orgb50a12a">
+<div id="outline-container-org3e8b7ee" class="outline-3">
+<h3 id="org3e8b7ee">Concurrency</h3>
+<div class="outline-text-3" id="text-org3e8b7ee">
 <ul class="org-ul">
 <li>Joseph Tassarotti, Robert Harper.
 <span class="underline">A Separation Logic for Concurrent Randomized Programs</span>.
@@ -485,9 +497,9 @@ ESOP 2014. <a href="https://doi.org/10.1007/978-3-642-54833-8_16">doi</a></li>
 </div>
 </div>
 
-<div id="outline-container-org3c8548e" class="outline-3">
-<h3 id="org3c8548e">Information Flow</h3>
-<div class="outline-text-3" id="text-org3c8548e">
+<div id="outline-container-orge5d4d01" class="outline-3">
+<h3 id="orge5d4d01">Information Flow</h3>
+<div class="outline-text-3" id="text-orge5d4d01">
 <ul class="org-ul">
 <li>Aleksandar Nanevski, Anindya Banerjee, Deepak Garg.
 <span class="underline">Dependent Type Theory for Verification of Information Flow and Access Control Policies</span>.
@@ -502,9 +514,9 @@ PPDP 2013. <a href="https://doi.org/10.1145/2505879.2505895">doi</a></li>
 </div>
 </div>
 
-<div id="outline-container-orgfde8dab" class="outline-3">
-<h3 id="orgfde8dab">Probabilistic Reasoning</h3>
-<div class="outline-text-3" id="text-orgfde8dab">
+<div id="outline-container-orgb58b163" class="outline-3">
+<h3 id="orgb58b163">Probabilistic Reasoning</h3>
+<div class="outline-text-3" id="text-orgb58b163">
 <ul class="org-ul">
 <li>Kiran Gopinathan, Ilya Sergey.
 <span class="underline">Certifying Certainty and Uncertainty in Approximate Membership Query Structures</span>.
@@ -520,9 +532,9 @@ Computer Software 37(3):79-95, 2020. <a href="https://staff.aist.go.jp/reynald.a
 </div>
 </div>
 
-<div id="outline-container-orge13ccce" class="outline-2">
-<h2 id="orge13ccce">Other Applications</h2>
-<div class="outline-text-2" id="text-orge13ccce">
+<div id="outline-container-orgbbd09cb" class="outline-2">
+<h2 id="orgbbd09cb">Other Applications</h2>
+<div class="outline-text-2" id="text-orgbbd09cb">
 <ul class="org-ul">
 <li>Pierre-Léo Bégay, Pierre Crégut, Jean-François Monin.
 <span class="underline">Developing and certifying Datalog optimizations in Coq/MathComp</span>. CPP 2021. <a href="https://hal.archives-ouvertes.fr/hal-03065304v1/document">pdf</a></li>
@@ -537,9 +549,9 @@ Linux Audio Conference 2015. <a href="https://github.com/ejgallego/mini-faust-co
 </ul>
 </div>
 
-<div id="outline-container-orgf72ae0a" class="outline-3">
-<h3 id="orgf72ae0a">Logic, Types, and Verification</h3>
-<div class="outline-text-3" id="text-orgf72ae0a">
+<div id="outline-container-org1de5e27" class="outline-3">
+<h3 id="org1de5e27">Logic, Types, and Verification</h3>
+<div class="outline-text-3" id="text-org1de5e27">
 <ul class="org-ul">
 <li>Christian Doczkal, Gert Smolka.
 <span class="underline">Regular Language Representations in the Constructive Type Theory of Coq</span>.
@@ -572,9 +584,9 @@ International Conference on Typed Lambda Calculi and Applications (TLCA 2011). <
 </div>
 </div>
 
-<div id="outline-container-orgc1865c0" class="outline-3">
-<h3 id="orgc1865c0">Information Theory</h3>
-<div class="outline-text-3" id="text-orgc1865c0">
+<div id="outline-container-orgb7d806a" class="outline-3">
+<h3 id="orgb7d806a">Information Theory</h3>
+<div class="outline-text-3" id="text-orgb7d806a">
 <ul class="org-ul">
 <li>Joshua M. Cohen, Qinshi Wang, Andrew W. Appel.
 <span class="underline">Verified Erasure Correction in Coq with MathComp and VST</span>.
@@ -603,10 +615,13 @@ International Symposium on Information Theory and its Application 2014 (ISITA 20
 </div>
 </div>
 
-<div id="outline-container-org03a559d" class="outline-2">
-<h2 id="org03a559d">Tooling about SSReflect and Mathematical Components</h2>
-<div class="outline-text-2" id="text-org03a559d">
+<div id="outline-container-orgda370c1" class="outline-2">
+<h2 id="orgda370c1">Tooling about SSReflect and Mathematical Components</h2>
+<div class="outline-text-2" id="text-orgda370c1">
 <ul class="org-ul">
+<li>Benjamin Grégoire, Jean-Christophe Léchenet, Enrico Tassi.
+_ Practical and sound equality tests, automatically_.
+CPP 2023. <a href="https://hal.inria.fr/hal-03800154/document">pdf</a></li>
 <li>Kazuhiko Sakaguchi. <span class="underline">Reflexive tactics for algebra, revisited</span>. ITP 2022. <a href="https://arxiv.org/pdf/2202.04330.pdf">pdf</a></li>
 <li>Reynald Affeldt, Xavier Allamigeon, Yves Bertot, Quentin Canu, Cyril Cohen, Pierre Roux, Kazuhiko Sakaguchi, Enrico Tassi, Laurent Théry, Anton Trunov.
 <span class="underline">Porting the Mathematical Components library to Hierarchy Builder</span>. Coq Workshop 2021. <a href="https://coq-workshop.gitlab.io/2021/abstracts/Coq2021-01-02-mathcomp-hierarchy-builder.pdf">pdf</a></li>
@@ -640,9 +655,9 @@ IPSJ Transactions on Programming 10(1), 2017. <a href="http://logic.cs.tsukuba.a
 </ul>
 </div>
 
-<div id="outline-container-org3830702" class="outline-3">
-<h3 id="org3830702">Machine Learning</h3>
-<div class="outline-text-3" id="text-org3830702">
+<div id="outline-container-orgda7279c" class="outline-3">
+<h3 id="orgda7279c">Machine Learning</h3>
+<div class="outline-text-3" id="text-orgda7279c">
 <ul class="org-ul">
 <li>Pengyu Nie, Karl Palmskog, Junyi Jessy Li, Milos Gligoric.
 <span class="underline">Deep Generation of Coq Lemma Names Using Elaborated Terms</span>. IJCAR 2020. <a href="https://arxiv.org/pdf/2004.07761.pdf">pdf</a></li>

--- a/papers.org
+++ b/papers.org
@@ -34,6 +34,9 @@ This is a memo to serve in the event we change the sectioning
 
 * Mathematics
 
+- Xavier Allamigeon, Quentin Canu, Pierre-Yves Strub.
+  _A Formal Disproof of Hirsch Conjecture_.
+  CPP 2023. [[https://arxiv.org/pdf/2301.04060.pdf][pdf]]
 - Xavier Allamigeon, Ricardo D. Katz, Pierre-Yves Strub.
   _Formalizing the Face Lattice of Polyhedra_.
   LMCS 18(2), 2022. [[https://lmcs.episciences.org/9570/pdf][pdf]]
@@ -145,6 +148,15 @@ This is a memo to serve in the event we change the sectioning
 
 * Programming and Algorithms
 
+- Li Zhou, Gilles Barthe, Pierre-Yves Strub, Junyi Liu, Mingsheng Ying.
+  _CoqQ: Foundational Verification of Quantum Programs_.
+  POPL 2023. [[https://arxiv.org/pdf/2207.11350.pdf][pdf]]
+- Reynald Affeldt, Cyril Cohen, Ayumu Saito.
+  _Semantics of Probabilistic Programs using s-Finite Kernels in Coq_.
+  CPP 2023. [[https://hal.inria.fr/hal-03917948/document][pdf]]
+- Ayumu Saito, Reynald Affeldt.
+  _Towards a Practical Library for Monadic Equational Reasoning in Coq_.
+  Mathematics of Program Construction (MPC 2022). [[https://staff.aist.go.jp/reynald.affeldt/documents/monae-mpc2022.pdf][pdf]]
 - Reynald Affeldt, Jacques Garrigue, David Nowak, Takafumi Saikawa.
   _A trustful monad for axiomatic reasoning with probability and nondeterminism_.
   JFP 31(E17), 2021. [[https://arxiv.org/pdf/2003.09993.pdf][pdf]]
@@ -304,6 +316,9 @@ This is a memo to serve in the event we change the sectioning
 
 * Tooling about SSReflect and Mathematical Components
 
+- Benjamin Grégoire, Jean-Christophe Léchenet, Enrico Tassi.
+  _ Practical and sound equality tests, automatically_.
+  CPP 2023. [[https://hal.inria.fr/hal-03800154/document][pdf]]
 - Kazuhiko Sakaguchi. _Reflexive tactics for algebra, revisited_. ITP 2022. [[https://arxiv.org/pdf/2202.04330.pdf][pdf]]
 - Reynald Affeldt, Xavier Allamigeon, Yves Bertot, Quentin Canu, Cyril Cohen, Pierre Roux, Kazuhiko Sakaguchi, Enrico Tassi, Laurent Théry, Anton Trunov.
   _Porting the Mathematical Components library to Hierarchy Builder_. Coq Workshop 2021. [[https://coq-workshop.gitlab.io/2021/abstracts/Coq2021-01-02-mathcomp-hierarchy-builder.pdf][pdf]]

--- a/papers.org
+++ b/papers.org
@@ -316,6 +316,9 @@ This is a memo to serve in the event we change the sectioning
 
 * Tooling about SSReflect and Mathematical Components
 
+- Valentin Blot, Denis Cousineau, Enzo Crance, Louise Dubois de Prisque, Chantal Keller, Assia Mahboubi, Pierre Vial.
+  _Compositional Pre-processing for Automated Reasoning in Dependent Type Theory_.
+  CPP 2023. [[https://arxiv.org/pdf/2204.02643.pdf][pdf]]
 - Benjamin Grégoire, Jean-Christophe Léchenet, Enrico Tassi.
   _ Practical and sound equality tests, automatically_.
   CPP 2023. [[https://hal.inria.fr/hal-03800154/document][pdf]]


### PR DESCRIPTION
I added a few papers in particular from CPP and POPL of which you are authors.
Please tell me if you think the category is not appropriate
(or if you disagree having your paper linked from the MathComp website).
@strub @CohenCyril @gares @QuentinCanu @nhojem

Also, I may have missed other papers using MathComp from the above conferences.
Please tell us if you noticed one.

Thank you.
